### PR TITLE
Potential fix for code scanning alert no. 24: Short global name

### DIFF
--- a/kattis/divisible.c
+++ b/kattis/divisible.c
@@ -5,7 +5,7 @@
 #define   REP(i, n)       FOR(i, 0, n)
 
 int S[1000000];
-int d;
+int divisor;
 
 int main()
 {
@@ -14,17 +14,17 @@ int main()
   scanf("%d\n", &T);
   REP(t, T)
   {
-    scanf("%d %d\n", &d, &n);
+    scanf("%d %d\n", &divisor, &n);
 
-    memset(S, '\0', sizeof(int)*d);
+    memset(S, '\0', sizeof(int)*divisor);
 
     ans = 0;
     sum = 0;
     REP(i, n)
     {
       scanf("%d", &s);
-      sum += s + d;
-      sum %= d;
+      sum += s + divisor;
+      sum %= divisor;
 
       ans += !(sum);
       ans += S[sum];

--- a/kattis/divisible.c
+++ b/kattis/divisible.c
@@ -22,7 +22,10 @@ int main()
     sum = 0;
     REP(i, n)
     {
-      scanf("%d", &s);
+      if (scanf("%d", &s) != 1) {
+        fprintf(stderr, "Error reading input for s\n");
+        return 1;
+      }
       sum += s + divisor;
       sum %= divisor;
 

--- a/kattis/divisible.c
+++ b/kattis/divisible.c
@@ -14,7 +14,10 @@ int main()
   scanf("%d\n", &T);
   REP(t, T)
   {
-    scanf("%d %d\n", &divisor, &n);
+    if (scanf("%d %d\n", &divisor, &n) != 2) {
+      fprintf(stderr, "Error reading input for divisor and/or n\n");
+      return 1;
+    }
 
     memset(S, '\0', sizeof(int)*divisor);
 


### PR DESCRIPTION
Potential fix for [https://github.com/iglesias/coding-challenges/security/code-scanning/24](https://github.com/iglesias/coding-challenges/security/code-scanning/24)

To fix the issue, the global variable `d` should be renamed to a more descriptive name that reflects its purpose in the program. Based on its usage, `d` appears to represent the divisor used in modular arithmetic operations. A suitable replacement name could be `divisor`. This change should be applied consistently throughout the code to ensure correctness.

Steps to implement the fix:
1. Replace all occurrences of `d` with `divisor` in the code.
2. Ensure that the new name does not conflict with any other variable names in the program.
3. Verify that the program compiles and runs correctly after the change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
